### PR TITLE
setup-environment: fix issue where ACCEPT_FSL_EULA could get overwritten

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -210,12 +210,12 @@ EOF
             ;;
         esac
     done
-fi
 
-if grep -q '^ACCEPT_FSL_EULA\s*=' conf/local.conf; then
-    sed -i "s/^#*ACCEPT_FSL_EULA\s*=.*/ACCEPT_FSL_EULA = \"$EULA\"/g" conf/local.conf
-else
-    echo "ACCEPT_FSL_EULA = \"$EULA\"" >> conf/local.conf
+    if grep -q '^ACCEPT_FSL_EULA\s*=' conf/local.conf; then
+        sed -i "s/^#*ACCEPT_FSL_EULA\s*=.*/ACCEPT_FSL_EULA = \"$EULA\"/g" conf/local.conf
+    else
+        echo "ACCEPT_FSL_EULA = \"$EULA\"" >> conf/local.conf
+    fi
 fi
 
 cat <<EOF


### PR DESCRIPTION
There is an issue when re-running (sourcing) the setup-environment script
to start a new build for example that would result in the ACCEPT_FSL_EULA
setting stored in local.conf getting overwritten. This means if the EULA
was previously accepted this fact would get discarded silently from
local.conf and with that this setting would be unavailable for the next
build.

This fix will ensure that the ACCEPT_FSL_EULA is only modified in local.conf
when the EULA question was actually asked, which typically happens the
first time the script is run.

Signed-off-by: Andreas Dannenberg dannenberg@me.com
