### PR TITLE
Ensure setup-environment invokes correct shell.

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # -*- mode: shell-script; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 #
 # Copyright (C) 2012, 2013 O.S. Systems Software LTDA.


### PR DESCRIPTION
setup-environment uses bash features which are not in POSIX shells,
so the shebang line needs to point to /bin/bash.
