### PR TITLE
bblayers: Change reference to meta-yocto to meta-poky

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -6,7 +6,7 @@ BSPDIR := "${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)) + '/../..'
 BBFILES ?= ""
 BBLAYERS = " \
   ${BSPDIR}/sources/poky/meta \
-  ${BSPDIR}/sources/poky/meta-yocto \
+  ${BSPDIR}/sources/poky/meta-poky \
   \
   ${BSPDIR}/sources/meta-openembedded/meta-oe \
   ${BSPDIR}/sources/meta-openembedded/meta-multimedia \


### PR DESCRIPTION
meta-yocto layer has been renamed to meta-poky to better match
its purpose. Yocto is part of the project name while poky is
the reference distribution.

Reflect this change in bblayers.conf.

Signed-off-by: Kursad Oney <kuoney@gmail.com>