### PR TITLE
setup-environment: Consider PACKAGE_CLASSES

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -22,6 +22,7 @@
 
 CWD=`pwd`
 PROGNAME="setup-environment"
+PACKAGE_CLASSES=${PACKAGE_CLASSES:-package_rpm}
 
 usage()
 {
@@ -161,6 +162,7 @@ EOF
     sed -e "s,MACHINE ??=.*,MACHINE ??= '$MACHINE',g" \
         -e "s,SDKMACHINE ??=.*,SDKMACHINE ??= '$SDKMACHINE',g" \
         -e "s,DISTRO ?=.*,DISTRO ?= '$DISTRO',g" \
+        -e "s,PACKAGE_CLASSES ?=.*,PACKAGE_CLASSES ?= '$PACKAGE_CLASSES',g" \
         -i conf/local.conf
 
     cp $TEMPLATES/* conf/


### PR DESCRIPTION
Besides MACHINE, SDKMACHINE and DISTRO, also consider PACKAGE_CLASSES
from environment.
Set 'package_rpm' as default.