### PR TITLE
conf/bblayers.conf: Enable python2 legacy support

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -11,6 +11,7 @@ BBLAYERS = " \
   ${BSPDIR}/sources/meta-openembedded/meta-oe \
   ${BSPDIR}/sources/meta-openembedded/meta-multimedia \
   ${BSPDIR}/sources/meta-openembedded/meta-python \
+  ${BSPDIR}/sources/meta-python2 \
   \
   ${BSPDIR}/sources/meta-freescale \
   ${BSPDIR}/sources/meta-freescale-3rdparty \


### PR DESCRIPTION
Add meta-python2 layer, until recipes porting to python3

Signed-off-by: Cristinel Panfir <cristinel.panfir@nxp.com>