### PR TITLE
[zeus] setup-environment: Facilitate EULA upgrades for NXP release process

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -131,6 +131,13 @@ if [ "$build_dir_setup_enabled" = "true" ] && [ -z "$DISTRO" ]; then
     return 1
 fi
 
+[ -z "$FSL_EULA_FILE" ] && FSL_EULA_FILE=$CWD/sources/meta-freescale/EULA
+if [ ! -e $FSL_EULA_FILE ]; then
+    echo -e "ERROR: EULA not found at $FSL_EULA_FILE."
+    clean_up
+    return 1
+fi
+
 OEROOT=$PWD/sources/poky
 if [ -e $PWD/sources/oe-core ]; then
     OEROOT=$PWD/sources/oe-core
@@ -208,7 +215,7 @@ EOF
 
     sleep 4
 
-    more -d $CWD/sources/meta-freescale/EULA
+    more -d $FSL_EULA_FILE
     echo
     REPLY=
     while [ -z "$REPLY" ]; do


### PR DESCRIPTION
NOTE: zeus is in sync with master, so this is a rebase of zeus on master, not a cherry-pick.

The NXP release process adds a new layer on top of meta-freescale, to
be used for some period of time before the release is integrated into
meta-freescale. The setup for an NXP release is done by an NXP setup
script that wraps the meta-freescale setup script, that in turn
performs the EULA click-through.

Each NXP release does often contain a new EULA license. Until now each
new EULA was handled by having the NXP setup script manually modify
the meta-freescale layer before calling the meta-freescale setup
script. This is a messy solution.

This fix allows the NXP setup script to override the default EULA
file to be used in the click-through.

Signed-off-by: Tom Hochstein <tom.hochstein@nxp.com>