### PR TITLE
Do not force overwrite bblayers.conf

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -175,7 +175,7 @@ EOF
         -e "s,PACKAGE_CLASSES ?=.*,PACKAGE_CLASSES ?= '$PACKAGE_CLASSES',g" \
         -i conf/local.conf
 
-    cp $TEMPLATES/* conf/
+    cp -n $TEMPLATES/* conf/
 
     for s in $HOME/.oe $HOME/.yocto; do
         if [ -e $s/site.conf ]; then


### PR DESCRIPTION
Before this commit, `setup-environment` replaced `bblayers.conf` on every run where no `local.conf` was available or generated by `oe-init-build-env`, even if `bblayers.conf` was generated by `oe-init-build-env` or manually created by the user.

Fixes #20 