### PR TITLE
setup-environment: Fix missing DISTRO in local.conf

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -165,6 +165,9 @@ if [ "$build_dir_setup_enabled" = "true" ]; then
 
 DL_DIR ?= "\${BSPDIR}/downloads/"
 EOF
+    if ! grep -q "DISTRO ?=" conf/local.conf; then
+        sed "1iDISTRO ?= '$DISTRO'" -i conf/local.conf
+    fi
     # Change settings according environment
     sed -e "s,MACHINE ??=.*,MACHINE ??= '$MACHINE',g" \
         -e "s,SDKMACHINE ??=.*,SDKMACHINE ??= '$SDKMACHINE',g" \


### PR DESCRIPTION
After running setup-environment, the DISTRO setting is missing in local.conf. With poky.git no longer used, the OE-Core version of local.conf.sample is now used. This file doesn't have any entry for DISTRO, so the command from setup-environment to set it to the current environment variable setting has no effect.